### PR TITLE
Really abstract

### DIFF
--- a/lib/e0.ml
+++ b/lib/e0.ml
@@ -12,7 +12,7 @@ module Make (Key : Sigs.FUNCTOR) = struct
 
   type 'a s = (module S with type x = 'a)
   type v = Value : 'a * 'a Key.t -> v
-  type k = Key : 'a Key.t -> k
+  type k = Key : 'a Key.t * ('a -> t) -> k
 
   let handlers = Hashtbl.create 16
   let witnesses = Hashtbl.create 16
@@ -31,7 +31,7 @@ module Make (Key : Sigs.FUNCTOR) = struct
       let[@warning "-3"] uid = Stdlib.Obj.extension_id [%extension_constructor T] in
       Hashtbl.add handlers uid
         (function T x -> Value (x, witness) | _ -> raise Not_found) ;
-      Hashtbl.add witnesses uid (Key witness)
+      Hashtbl.add witnesses uid (Key (witness, (fun x -> T x)))
   end
 
   let inj (type a) (k : a Key.t) : a s =

--- a/lib/e0.mli
+++ b/lib/e0.mli
@@ -11,7 +11,7 @@ module Make (Key : Sigs.FUNCTOR) : sig
 
   type 'a s = (module S with type x = 'a)
   type v = Value : 'a * 'a Key.t -> v
-  type k = Key : 'a Key.t -> k
+  type k = Key : 'a Key.t * ('a -> t) -> k
 
   val inj : 'a Key.t -> 'a s
   val prj : t -> v

--- a/lib/tuyau.mli
+++ b/lib/tuyau.mli
@@ -181,7 +181,7 @@ module type S = sig
           | _ -> failwith "Flow.recv"
       ]}
   *)
-  type flow = Flow : 'flow * (module FLOW with type flow = 'flow) -> flow
+  type flow
 
   val recv : flow -> input -> (int Sigs.or_end_of_input, [> `Msg of string ]) result s
   val send : flow -> output -> (int, [> `Msg of string ]) result s
@@ -504,6 +504,8 @@ module type S = sig
         [> error ]) result
 
   val impl_of_flow : 'flow Witness.protocol -> (module FLOW with type flow = 'flow)
+
+  val is : flow -> 'flow Witness.protocol -> 'flow option
 end
 
 (** {3 Composition.}

--- a/mirage/tuyau_mirage_tls.mli
+++ b/mirage/tuyau_mirage_tls.mli
@@ -3,6 +3,7 @@ open Tuyau_mirage
 type 'flow protocol_with_tls
 
 val underlying : 'flow protocol_with_tls -> 'flow
+val handshake : 'flow protocol_with_tls -> bool
 
 val protocol_with_tls :
   key:'edn key ->

--- a/tls/tuyau_tls.mli
+++ b/tls/tuyau_tls.mli
@@ -7,6 +7,7 @@ module Make
     type 'flow protocol_with_tls
 
     val underlying : 'flow protocol_with_tls -> 'flow
+    val handshake : 'flow protocol_with_tls -> bool
 
     val protocol_with_tls :
       key:'edn Tuyau.key ->


### PR DESCRIPTION
The goal of this PR is to completely abstract our type flow. At the end, for a library such as `Paf`, we can play with `receive`/`send` without to know what we really use. However, for complex computation such as HTTP/AF with TLS layer, we must re-extract our flow to be able to use `handshake` - and avoid a mis-computation between HTTP/AF and handshake process.